### PR TITLE
Handle discordbot user agent embed by returning a 406

### DIFF
--- a/src/Security/DiscordAuthenticator.php
+++ b/src/Security/DiscordAuthenticator.php
@@ -117,7 +117,7 @@ class DiscordAuthenticator extends SocialAuthenticator
     {
         $userAgent = $request->headers->get('User-Agent');
         if (str_contains($userAgent, 'Discordbot')) {
-            return new Response(Response::HTTP_NOT_ACCEPTABLE);
+            return new Response(Response::HTTP_PRECONDITION_FAILED);
         }
 
         $routeName = $request->attributes->get('_route');

--- a/src/Security/DiscordAuthenticator.php
+++ b/src/Security/DiscordAuthenticator.php
@@ -115,6 +115,11 @@ class DiscordAuthenticator extends SocialAuthenticator
      */
     public function start(Request $request, AuthenticationException $authException = null)
     {
+        $userAgent = $request->headers->get('User-Agent');
+        if (str_contains($userAgent, 'Discordbot')) {
+            return new Response(Response::HTTP_NOT_ACCEPTABLE);
+        }
+
         $routeName = $request->attributes->get('_route');
         $routeParameters = $request->attributes->get('_route_params');
 


### PR DESCRIPTION
This will retain the default link embed for the homepage but return a 406 Not Acceptable when the discordbot tries to scrape an event resource for meta links instead of the large discord login embed that displays currently.